### PR TITLE
Adding controller and some model unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,19 @@ The properties file used by the application is chosen automatically based on the
 Alternatively -Dspring.config.location can be used in the command line to override the packaged properties file.
 
 #### Run (in place for development purposes)
-Depending on whether mongo or redis is used, the active profile will need to be sent in as a command line arg
-* mvn -Drun.jvmArguments="-Dspring.profiles.active=mongo" clean package spring-boot:run
-* mvn -Drun.jvmArguments="-Dspring.profiles.active=redis" clean package spring-boot:run
+Depending on whether mongo or redis is used, the active profile will need to be sent in as a command line arg.
+The profile needs to have two command line args, one for unit tests and once for runtime.
+* mvn -Drun.jvmArguments="-Dspring.profiles.active=mongo" -Dspring.profiles.active=mongo clean package spring-boot:run
+* mvn -Drun.jvmArguments="-Dspring.profiles.active=redis" -Dspring.profiles.active=redis clean package spring-boot:run
 
 #### Deploy
 Depending on whether mongo or redis is used, the active profile will need to be sent in as a command line arg
 * java -jar -Dspring.profiles.active=mongo target/opendash*.jar
 * java -jar -Dspring.profiles.active=redis target/opendash*.jar
+
+#### Test
+mvn -Dspring.profiles.active=mongo clean test
+mvn -Dspring.profiles.active=redis clean test
 
 This starts OpenDashboard on port 8080. Changing the server port (and other properties) can be done on the command line (http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html)
 *************************************************************************************

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,17 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.3.2</version>
         </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.openpojo</groupId>
+            <artifactId>openpojo</artifactId>
+            <version>0.6.2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,7 +92,105 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.15</version>
+                <configuration>
+                  <!-- Toggle to Run Tests -->
+                  <groups>od.test.groups.ControllerUnitTests,
+                          od.test.groups.ModelUnitTests
+                  </groups>
+                  <excludedGroups></excludedGroups>
+                  <includes>
+                    <include>**/*Tests.java</include>
+                    <include>**/*Test.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/Abstract*.java</exclude>
+                  </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+            <!-- Test Coverage Report found in /target/site/jacoco/index.html -->
+               <groupId>org.jacoco</groupId>
+               <artifactId>jacoco-maven-plugin</artifactId>
+               <version>0.7.2.201409121644</version>
+               <configuration>
+                   <excludes>
+                  </excludes>
+              </configuration>
+              <executions>
+                  <execution>
+                  <id>pre-unit-test</id>
+                  <goals>
+                      <goal>prepare-agent</goal>
+                  </goals>
+                  </execution>
+                  <execution>
+                      <id>post-unit-test</id>
+                      <phase>test</phase>
+                  <goals>
+                      <goal>report</goal>
+                      <goal>check</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                    <!--  implmentation is needed only for Maven 2  -->
+                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                        <element>BUNDLE</element>
+                        <limits>
+                        <limit implementation="org.jacoco.report.check.Limit">
+                          <counter>INSTRUCTION</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>0.0</minimum>         
+                        </limit>
+                        <!--  implmentation is needed only for Maven 2  -->
+                        <limit implementation="org.jacoco.report.check.Limit">
+                          <counter>COMPLEXITY</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>0.0</minimum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
+                </configuration>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.jacoco</groupId>
+                                        <artifactId>
+                                            jacoco-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [0.7.2.201409121644,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>prepare-agent</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <licenses>

--- a/src/main/java/lti/LaunchRequest.java
+++ b/src/main/java/lti/LaunchRequest.java
@@ -596,4 +596,116 @@ public class LaunchRequest extends LtiMessage {
     public void setExtra(Map<String, String> extra) {
         this.extra = extra;
     }
+
+    public void setResource_link_id(String resource_link_id) {
+        this.resource_link_id = resource_link_id;
+    }
+
+    public void setContext_id(String context_id) {
+        this.context_id = context_id;
+    }
+
+    public void setLaunch_presentation_document_target(String launch_presentation_document_target) {
+        this.launch_presentation_document_target = launch_presentation_document_target;
+    }
+
+    public void setLaunch_presentation_width(String launch_presentation_width) {
+        this.launch_presentation_width = launch_presentation_width;
+    }
+
+    public void setLaunch_presentation_height(String launch_presentation_height) {
+        this.launch_presentation_height = launch_presentation_height;
+    }
+
+    public void setLaunch_presentation_return_url(String launch_presentation_return_url) {
+        this.launch_presentation_return_url = launch_presentation_return_url;
+    }
+
+    public void setUser_id(String user_id) {
+        this.user_id = user_id;
+    }
+
+    public void setRoles(String roles) {
+        this.roles = roles;
+    }
+
+    public void setContext_type(String context_type) {
+        this.context_type = context_type;
+    }
+
+    public void setLaunch_presentation_locale(String launch_presentation_locale) {
+        this.launch_presentation_locale = launch_presentation_locale;
+    }
+
+    public void setLaunch_presentation_css_url(String launch_presentation_css_url) {
+        this.launch_presentation_css_url = launch_presentation_css_url;
+    }
+
+    public void setRole_scope_mentor(String role_scope_mentor) {
+        this.role_scope_mentor = role_scope_mentor;
+    }
+
+    public void setUser_image(String user_image) {
+        this.user_image = user_image;
+    }
+
+    public void setResource_link_description(String resource_link_description) {
+        this.resource_link_description = resource_link_description;
+    }
+
+    public void setLis_person_name_given(String lis_person_name_given) {
+        this.lis_person_name_given = lis_person_name_given;
+    }
+
+    public void setLis_person_name_full(String lis_person_name_full) {
+        this.lis_person_name_full = lis_person_name_full;
+    }
+
+    public void setLis_person_contact_email_primary(String lis_person_contact_email_primary) {
+        this.lis_person_contact_email_primary = lis_person_contact_email_primary;
+    }
+
+    public void setLis_outcome_service_url(String lis_outcome_service_url) {
+        this.lis_outcome_service_url = lis_outcome_service_url;
+    }
+
+    public void setLis_result_sourcedid(String lis_result_sourcedid) {
+        this.lis_result_sourcedid = lis_result_sourcedid;
+    }
+
+    public void setContext_title(String context_title) {
+        this.context_title = context_title;
+    }
+
+    public void setContext_label(String context_label) {
+        this.context_label = context_label;
+    }
+
+    public void setTool_consumer_info_product_family_code(String tool_consumer_info_product_family_code) {
+        this.tool_consumer_info_product_family_code = tool_consumer_info_product_family_code;
+    }
+
+    public void setTool_consumer_info_version(String tool_consumer_info_version) {
+        this.tool_consumer_info_version = tool_consumer_info_version;
+    }
+
+    public void setTool_consumer_instance_guid(String tool_consumer_instance_guid) {
+        this.tool_consumer_instance_guid = tool_consumer_instance_guid;
+    }
+
+    public void setTool_consumer_instance_name(String tool_consumer_instance_name) {
+        this.tool_consumer_instance_name = tool_consumer_instance_name;
+    }
+
+    public void setTool_consumer_instance_description(String tool_consumer_instance_description) {
+        this.tool_consumer_instance_description = tool_consumer_instance_description;
+    }
+
+    public void setTool_consumer_instance_url(String tool_consumer_instance_url) {
+        this.tool_consumer_instance_url = tool_consumer_instance_url;
+    }
+
+    public void setTool_consumer_instance_contact_email(String tool_consumer_instance_contact_email) {
+        this.tool_consumer_instance_contact_email = tool_consumer_instance_contact_email;
+    }
 }

--- a/src/main/java/lti/LtiMessage.java
+++ b/src/main/java/lti/LtiMessage.java
@@ -8,7 +8,7 @@ package lti;
 public abstract class LtiMessage {
     protected String lti_message_type;
     protected String lti_version;
-    
+
     /* OAuth Parameters */
     protected String oauth_consumer_key;
     protected String oauth_signature_method;
@@ -17,7 +17,7 @@ public abstract class LtiMessage {
     protected String oauth_version;
     protected String oauth_signature;
     protected String oauth_callback;
-    
+
     public LtiMessage() {}
 
     public LtiMessage(String lti_message_type, String lti_version,
@@ -60,5 +60,41 @@ public abstract class LtiMessage {
     }
     public String getOauth_callback() {
         return oauth_callback;
+    }
+
+    public void setLti_message_type(String lti_message_type) {
+        this.lti_message_type = lti_message_type;
+    }
+
+    public void setLti_version(String lti_version) {
+        this.lti_version = lti_version;
+    }
+
+    public void setOauth_consumer_key(String oauth_consumer_key) {
+        this.oauth_consumer_key = oauth_consumer_key;
+    }
+
+    public void setOauth_signature_method(String oauth_signature_method) {
+        this.oauth_signature_method = oauth_signature_method;
+    }
+
+    public void setOauth_timestamp(String oauth_timestamp) {
+        this.oauth_timestamp = oauth_timestamp;
+    }
+
+    public void setOauth_nonce(String oauth_nonce) {
+        this.oauth_nonce = oauth_nonce;
+    }
+
+    public void setOauth_version(String oauth_version) {
+        this.oauth_version = oauth_version;
+    }
+
+    public void setOauth_signature(String oauth_signature) {
+        this.oauth_signature = oauth_signature;
+    }
+
+    public void setOauth_callback(String oauth_callback) {
+        this.oauth_callback = oauth_callback;
     }
 }

--- a/src/main/java/lti/ProxiedLaunch.java
+++ b/src/main/java/lti/ProxiedLaunch.java
@@ -1,0 +1,24 @@
+package lti;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class ProxiedLaunch implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private Map<String, String> params;
+    private String launchUrl;
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+
+    public String getLaunchUrl() {
+        return launchUrl;
+    }
+
+    public ProxiedLaunch(Map<String, String> params, String launchUrl) {
+        super();
+        this.params = params;
+        this.launchUrl = launchUrl;
+    }
+}

--- a/src/main/java/od/SecurityConfig.java
+++ b/src/main/java/od/SecurityConfig.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package od;
 
@@ -19,6 +19,7 @@ import org.springframework.boot.context.embedded.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -33,7 +34,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @EnableWebSecurity
 public class SecurityConfig {
 	@Autowired private OAuthFilter oAuthFilter;
-	
+
 	@Bean
 	public FilterRegistrationBean oAuthFilterBean() {
 		FilterRegistrationBean registrationBean = new FilterRegistrationBean();
@@ -44,16 +45,16 @@ public class SecurityConfig {
 		registrationBean.setOrder(2);
 		return registrationBean;
 	}
-    
+
     @Order(99)
     @Configuration
     public static class NoAuthConfigurationAdapter extends WebSecurityConfigurerAdapter {
 		@Value("${auth.oauth.key}")
 		private String securityKey;
-		
+
 		@Value("${auth.oauth.secret}")
-		private String securitySecret;		
-		
+		private String securitySecret;
+
 		@Autowired private LTIUserDetailsService userDetailsService;
 
         @Override
@@ -71,7 +72,13 @@ public class SecurityConfig {
             .antMatchers("/").permitAll()
             .anyRequest().authenticated().and().csrf().disable();
         }
-        
+
+        @Override
+        @Bean
+        public AuthenticationManager authenticationManagerBean() throws Exception {
+            return super.authenticationManagerBean();
+        }
+
         @Autowired
         public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
 //            auth
@@ -79,13 +86,13 @@ public class SecurityConfig {
 //            .withUser(securityKey + "-Instructor").password(securitySecret).roles("INSTRUCTOR")
 //            .and()
 //            .withUser(securityKey + "-Student").password(securitySecret).roles("STUDENT");
-            
+
             auth
             //.authenticationProvider(authenticationProvider)
             .userDetailsService(userDetailsService);
         }
     }
-	
+
 	@Bean
 	public SessionTrackingConfigListener sessionTrackingConfigListener() {
 		return new SessionTrackingConfigListener();

--- a/src/main/java/od/model/OpenDashboardModel.java
+++ b/src/main/java/od/model/OpenDashboardModel.java
@@ -7,8 +7,10 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.Id;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class OpenDashboardModel implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/od/repository/redis/model/RedisLaunchRequest.java
+++ b/src/main/java/od/repository/redis/model/RedisLaunchRequest.java
@@ -3,13 +3,7 @@
  */
 package od.repository.redis.model;
 
-import java.util.Map;
-import java.util.TreeMap;
-
 import lti.LtiMessage;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author ggilbert
@@ -55,151 +49,6 @@ public class RedisLaunchRequest extends LtiMessage {
     private String tool_consumer_instance_contact_email;
 
     public RedisLaunchRequest() {}
-
-    public RedisLaunchRequest(Map<String, String []> paramMap) {
-        Map<String,String> flattenedParams = new TreeMap<String, String>();
-
-        for (String key : paramMap.keySet()) {
-            String [] values = paramMap.get(key);
-            String value = null;
-            if (values != null && values.length > 0) {
-                for (String v : values) {
-                    if (value == null) {
-                        value = v;
-                    }
-                    else {
-                        value = value.concat(",");
-                        value = value.concat(v);
-                    }
-                }
-            }
-            flattenedParams.put(key, value);
-        }
-    }
-
-    @JsonCreator
-    public RedisLaunchRequest(
-            @JsonProperty("lti_message_type") String lti_message_type,
-            @JsonProperty("lti_version") String lti_version,
-            @JsonProperty("resource_link_id") String resource_link_id,
-            @JsonProperty("context_id") String context_id,
-            @JsonProperty("launch_presentation_document_target") String launch_presentation_document_target,
-            @JsonProperty("launch_presentation_width") String launch_presentation_width,
-            @JsonProperty("launch_presentation_height") String launch_presentation_height,
-            @JsonProperty("launch_presentation_return_url") String launch_presentation_return_url,
-            @JsonProperty("user_id") String user_id,
-            @JsonProperty("roles") String roles,
-            @JsonProperty("context_type") String context_type,
-            @JsonProperty("launch_presentation_locale") String launch_presentation_locale,
-            @JsonProperty("launch_presentation_css_url") String launch_presentation_css_url,
-            @JsonProperty("role_scope_mentor") String role_scope_mentor,
-            @JsonProperty("user_image") String user_image,
-            @JsonProperty("resource_link_title") String resource_link_title,
-            @JsonProperty("resource_link_description") String resource_link_description,
-            @JsonProperty("lis_person_name_given") String lis_person_name_given,
-            @JsonProperty("lis_person_name_family") String lis_person_name_family,
-            @JsonProperty("lis_person_name_full") String lis_person_name_full,
-            @JsonProperty("lis_person_contact_email_primary") String lis_person_contact_email_primary,
-            @JsonProperty("lis_outcome_service_url") String lis_outcome_service_url,
-            @JsonProperty("lis_result_sourcedid") String lis_result_sourcedid,
-            @JsonProperty("context_title") String context_title,
-            @JsonProperty("context_label") String context_label,
-            @JsonProperty("tool_consumer_info_product_family_code") String tool_consumer_info_product_family_code,
-            @JsonProperty("tool_consumer_info_version") String tool_consumer_info_version,
-            @JsonProperty("tool_consumer_instance_guid") String tool_consumer_instance_guid,
-            @JsonProperty("tool_consumer_instance_name") String tool_consumer_instance_name,
-            @JsonProperty("tool_consumer_instance_description") String tool_consumer_instance_description,
-            @JsonProperty("tool_consumer_instance_url") String tool_consumer_instance_url,
-            @JsonProperty("tool_consumer_instance_contact_email") String tool_consumer_instance_contact_email,
-            @JsonProperty("oauth_consumer_key") String oauth_consumer_key,
-            @JsonProperty("oauth_signature_method") String oauth_signature_method,
-            @JsonProperty("oauth_timestamp") String oauth_timestamp,
-            @JsonProperty("oauth_nonce") String oauth_nonce,
-            @JsonProperty("oauth_version") String oauth_version,
-            @JsonProperty("oauth_signature") String oauth_signature,
-            @JsonProperty("oauth_callback") String oauth_callback) {
-
-        super(lti_message_type, lti_version,
-                oauth_consumer_key, oauth_signature_method,
-                oauth_timestamp, oauth_nonce, oauth_version,
-                oauth_signature, oauth_callback);
-
-        this.resource_link_id = resource_link_id;
-        this.context_id = context_id;
-        this.launch_presentation_document_target = launch_presentation_document_target;
-        this.launch_presentation_width = launch_presentation_width;
-        this.launch_presentation_height = launch_presentation_height;
-        this.launch_presentation_return_url = launch_presentation_return_url;
-        this.user_id = user_id;
-        this.roles = roles;
-        this.context_type = context_type;
-        this.launch_presentation_locale = launch_presentation_locale;
-        this.launch_presentation_css_url = launch_presentation_css_url;
-        this.role_scope_mentor = role_scope_mentor;
-        this.user_image = user_image;
-        this.resource_link_title = resource_link_title;
-        this.resource_link_description = resource_link_description;
-        this.lis_person_name_given = lis_person_name_given;
-        this.lis_person_name_family = lis_person_name_family;
-        this.lis_person_name_full = lis_person_name_full;
-        this.lis_person_contact_email_primary = lis_person_contact_email_primary;
-        this.lis_outcome_service_url = lis_outcome_service_url;
-        this.lis_result_sourcedid = lis_result_sourcedid;
-        this.context_title = context_title;
-        this.context_label = context_label;
-        this.tool_consumer_info_product_family_code = tool_consumer_info_product_family_code;
-        this.tool_consumer_info_version = tool_consumer_info_version;
-        this.tool_consumer_instance_guid = tool_consumer_instance_guid;
-        this.tool_consumer_instance_name = tool_consumer_instance_name;
-        this.tool_consumer_instance_description = tool_consumer_instance_description;
-        this.tool_consumer_instance_url = tool_consumer_instance_url;
-        this.tool_consumer_instance_contact_email = tool_consumer_instance_contact_email;
-    }
-
-    @Override
-    public String toString() {
-        return "LaunchRequest [resource_link_id=" + resource_link_id
-                + ", context_id=" + context_id
-                + ", launch_presentation_document_target="
-                + launch_presentation_document_target
-                + ", launch_presentation_width=" + launch_presentation_width
-                + ", launch_presentation_height=" + launch_presentation_height
-                + ", launch_presentation_return_url="
-                + launch_presentation_return_url + ", user_id=" + user_id
-                + ", roles=" + roles + ", context_type=" + context_type
-                + ", launch_presentation_locale=" + launch_presentation_locale
-                + ", launch_presentation_css_url="
-                + launch_presentation_css_url + ", role_scope_mentor="
-                + role_scope_mentor + ", user_image=" + user_image
-                + ", oauth_consumer_key=" + oauth_consumer_key
-                + ", oauth_signature_method=" + oauth_signature_method
-                + ", oauth_timestamp=" + oauth_timestamp + ", oauth_nonce="
-                + oauth_nonce + ", oauth_version=" + oauth_version
-                + ", oauth_signature=" + oauth_signature + ", oauth_callback="
-                + oauth_callback + ", resource_link_title="
-                + resource_link_title + ", resource_link_description="
-                + resource_link_description + ", lis_person_name_given="
-                + lis_person_name_given + ", lis_person_name_family="
-                + lis_person_name_family + ", lis_person_name_full="
-                + lis_person_name_full + ", lis_person_contact_email_primary="
-                + lis_person_contact_email_primary
-                + ", lis_outcome_service_url=" + lis_outcome_service_url
-                + ", lis_result_sourcedid=" + lis_result_sourcedid
-                + ", context_title=" + context_title + ", context_label="
-                + context_label + ", tool_consumer_info_product_family_code="
-                + tool_consumer_info_product_family_code
-                + ", tool_consumer_info_version=" + tool_consumer_info_version
-                + ", tool_consumer_instance_guid="
-                + tool_consumer_instance_guid
-                + ", tool_consumer_instance_name="
-                + tool_consumer_instance_name
-                + ", tool_consumer_instance_description="
-                + tool_consumer_instance_description
-                + ", tool_consumer_instance_url=" + tool_consumer_instance_url
-                + ", tool_consumer_instance_contact_email="
-                + tool_consumer_instance_contact_email + ", lti_message_type="
-                + lti_message_type + ", lti_version=" + lti_version + "]";
-    }
 
     public String getResource_link_id() {
         return resource_link_id;
@@ -327,5 +176,117 @@ public class RedisLaunchRequest extends LtiMessage {
 
     public String getTool_consumer_instance_contact_email() {
         return tool_consumer_instance_contact_email;
+    }
+
+    public void setResource_link_id(String resource_link_id) {
+        this.resource_link_id = resource_link_id;
+    }
+
+    public void setContext_id(String context_id) {
+        this.context_id = context_id;
+    }
+
+    public void setLaunch_presentation_document_target(String launch_presentation_document_target) {
+        this.launch_presentation_document_target = launch_presentation_document_target;
+    }
+
+    public void setLaunch_presentation_width(String launch_presentation_width) {
+        this.launch_presentation_width = launch_presentation_width;
+    }
+
+    public void setLaunch_presentation_height(String launch_presentation_height) {
+        this.launch_presentation_height = launch_presentation_height;
+    }
+
+    public void setLaunch_presentation_return_url(String launch_presentation_return_url) {
+        this.launch_presentation_return_url = launch_presentation_return_url;
+    }
+
+    public void setUser_id(String user_id) {
+        this.user_id = user_id;
+    }
+
+    public void setRoles(String roles) {
+        this.roles = roles;
+    }
+
+    public void setContext_type(String context_type) {
+        this.context_type = context_type;
+    }
+
+    public void setLaunch_presentation_locale(String launch_presentation_locale) {
+        this.launch_presentation_locale = launch_presentation_locale;
+    }
+
+    public void setLaunch_presentation_css_url(String launch_presentation_css_url) {
+        this.launch_presentation_css_url = launch_presentation_css_url;
+    }
+
+    public void setRole_scope_mentor(String role_scope_mentor) {
+        this.role_scope_mentor = role_scope_mentor;
+    }
+
+    public void setUser_image(String user_image) {
+        this.user_image = user_image;
+    }
+
+    public void setResource_link_description(String resource_link_description) {
+        this.resource_link_description = resource_link_description;
+    }
+
+    public void setLis_person_name_given(String lis_person_name_given) {
+        this.lis_person_name_given = lis_person_name_given;
+    }
+
+    public void setLis_person_name_full(String lis_person_name_full) {
+        this.lis_person_name_full = lis_person_name_full;
+    }
+
+    public void setLis_person_contact_email_primary(String lis_person_contact_email_primary) {
+        this.lis_person_contact_email_primary = lis_person_contact_email_primary;
+    }
+
+    public void setLis_outcome_service_url(String lis_outcome_service_url) {
+        this.lis_outcome_service_url = lis_outcome_service_url;
+    }
+
+    public void setLis_result_sourcedid(String lis_result_sourcedid) {
+        this.lis_result_sourcedid = lis_result_sourcedid;
+    }
+
+    public void setContext_title(String context_title) {
+        this.context_title = context_title;
+    }
+
+    public void setContext_label(String context_label) {
+        this.context_label = context_label;
+    }
+
+    public void setTool_consumer_info_product_family_code(String tool_consumer_info_product_family_code) {
+        this.tool_consumer_info_product_family_code = tool_consumer_info_product_family_code;
+    }
+
+    public void setTool_consumer_info_version(String tool_consumer_info_version) {
+        this.tool_consumer_info_version = tool_consumer_info_version;
+    }
+
+    public void setTool_consumer_instance_guid(String tool_consumer_instance_guid) {
+        this.tool_consumer_instance_guid = tool_consumer_instance_guid;
+    }
+
+    public void setTool_consumer_instance_name(String tool_consumer_instance_name) {
+        this.tool_consumer_instance_name = tool_consumer_instance_name;
+    }
+
+    public void setTool_consumer_instance_description(String tool_consumer_instance_description) {
+        this.tool_consumer_instance_description = tool_consumer_instance_description;
+    }
+
+    public void setTool_consumer_instance_url(String tool_consumer_instance_url) {
+        this.tool_consumer_instance_url = tool_consumer_instance_url;
+    }
+
+    public void setTool_consumer_instance_contact_email(String tool_consumer_instance_contact_email) {
+        this.tool_consumer_instance_contact_email = tool_consumer_instance_contact_email;
     }
 }

--- a/src/main/java/od/utils/AppControllerAdvice.java
+++ b/src/main/java/od/utils/AppControllerAdvice.java
@@ -1,0 +1,57 @@
+package od.utils;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.ModelAndView;
+
+@ControllerAdvice
+public class AppControllerAdvice {
+    private static final String X_REQUESTED_WITH_HEADER_NAME = "X-Requested-With";
+    private static final String X_REQUESTED_WITH_AJAX_VALUE = "XMLHttpRequest";
+    private static final Logger logger = LoggerFactory.getLogger(AppControllerAdvice.class);
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody Object handleAppException(HttpServletRequest request, Exception ex) throws IOException {
+        logger.error("Exception", ex);
+        if (isAjaxCall(request)) {
+            logger.error(ex.getMessage(), ex);
+            Response response = new Response();
+            response.setErrors(Arrays.asList(ex.getMessage()));
+            response.setData(ExceptionUtils.getStackTrace(ex));
+            response.setUrl(request.getRequestURL().toString());
+            return response;
+        } else {
+            ModelAndView modelAndView = new ModelAndView("error");
+            logger.error(ex.getMessage(), ex);
+            Response response = new Response();
+            response.setErrors(Arrays.asList(ex.getMessage()));
+            response.setData(ExceptionUtils.getStackTrace(ex));
+            response.setUrl(request.getRequestURL().toString());
+            modelAndView.addObject("response", response);
+            return modelAndView;
+        }
+    }
+
+    private boolean isAjaxCall(HttpServletRequest request) {
+        boolean isAjaxCall = false;
+        String xRequestedWithHeaderValue = request.getHeader(X_REQUESTED_WITH_HEADER_NAME);
+        if (!StringUtils.isEmpty(xRequestedWithHeaderValue) && xRequestedWithHeaderValue.equalsIgnoreCase(X_REQUESTED_WITH_AJAX_VALUE)) {
+            isAjaxCall = true;
+        }
+        return isAjaxCall;
+    }
+
+}

--- a/src/main/java/od/utils/Response.java
+++ b/src/main/java/od/utils/Response.java
@@ -1,0 +1,57 @@
+package od.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class Response {
+    String url;
+    List<String> errors;
+    Object data;
+
+    public Response() {
+        this.errors = new ArrayList<String>();
+    }
+
+    public Response(String url) {
+        this.errors = new ArrayList<String>();
+        this.url = url;
+    }
+
+    public Response(String url, Object data) {
+        this.errors = new ArrayList<String>();
+        this.url = url;
+        this.data = data;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+    }
+}

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -24,6 +24,23 @@
             <div class="col-xs-10">
                 <h3 class="text-center">Oops!</h3>
                 <h4 class="text-center">Something happened that won't allow you to see your dashboard. Sorry!</h4>
+                <div class="form-group" th:if="${error} != null">
+                    <h4 class="text-center" th:text="'Error Type: ' + ${error}">Bad</h4>
+                </div>
+                <div class="form-group" th:if="${status} != null">
+                    <h4 class="text-center" th:text="'Error Status: ' + ${status}">500</h4>
+                </div>
+                <div class="form-group" th:if="${response} != null">
+                    <div class="form-group" th:if="${response.url} != null">
+                        <h4 class="text-center" th:text="'Error Url: ' + ${response.url}">Error Url</h4>
+                    </div>
+                    <div class="form-group" th:if="${response.errors} != null">
+                        <h4 class="text-center" th:text="'Error: ' + ${response.errors}">Error</h4>
+                    </div>
+                    <div class="form-group" th:if="${response.data} != null">
+                        <h4 class="text-center" style="visibility:hidden;" th:text="'Error Data: ' + ${response.data}">Error Data</h4>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/test/java/od/AbstractTest.java
+++ b/src/test/java/od/AbstractTest.java
@@ -1,0 +1,43 @@
+package od;
+
+import java.io.IOException;
+
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {Application.class, SecurityConfig.class})
+public abstract class AbstractTest {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * Little helper method to log the JSON of an object in pretty-print for debug/test purposes
+     * @param obj
+     * @throws IOException
+     */
+    protected void asJson(Object obj) throws IOException {
+        logger.info(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj));
+    }
+
+    // There isn't an anyClass implementation so these methods provide that functionality
+    protected static class AnyClassMatcher extends ArgumentMatcher<Class<?>> {
+        @Override
+        public boolean matches(final Object argument) {
+            return true;
+        }
+    }
+
+    protected Class<?> anyClass() {
+        return Mockito.argThat(new AnyClassMatcher());
+    }
+}

--- a/src/test/java/od/controller/tests/ContextMappingControllerTest.java
+++ b/src/test/java/od/controller/tests/ContextMappingControllerTest.java
@@ -1,0 +1,173 @@
+package od.controller.tests;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import od.controllers.rest.ContextMappingController;
+import od.model.ContextMapping;
+import od.repository.ContextMappingRepositoryInterface;
+import od.utils.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class ContextMappingControllerTest extends ControllerTests {
+    private static final Logger logger = LoggerFactory.getLogger(ContextMappingControllerTest.class);
+
+    @Mock
+    private ContextMappingRepositoryInterface contextMappingRepository;
+
+    @InjectMocks
+    private ContextMappingController contextMappingController;
+
+    private MockMvc mockMvc;
+    private Response serviceFailureExpectedResponse;
+    private ContextMapping contextMapping;
+
+    // Setting up to have the spring app context in place while still being able to mock/control
+    // the services the controller uses.
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        MockitoAnnotations.initMocks(this);
+        session = this.createSession();
+        serviceFailureExpectedResponse = createServiceCallExceptionExpectedResponse();
+        contextMapping = new ContextMapping();
+        this.mockMvc = this.createMockMvc(contextMappingController);
+    }
+
+    @Test
+    public void doesCreateReturnProperJsonWhenGivenValidInput() throws Exception {
+        given(contextMappingRepository.save((ContextMapping) anyObject())).willReturn(contextMapping);
+
+        mockMvc.perform(post("/api/consumer/{consumerKey}/context", "consumerKey")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(testObjectMapper.writeValueAsString(contextMapping)));
+    }
+
+    @Test
+    public void doesCreateReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/consumer/consumerKey/context");
+
+        given(contextMappingRepository.save((ContextMapping) anyObject())).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = mockMvc.perform(post("/api/consumer/{consumerKey}/context", "consumerKey").session(session)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                                        .andReturn();
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    @Test
+    public void doesUpdateReturnProperJsonWhenGivenValidInput() throws Exception {
+        given(contextMappingRepository.save((ContextMapping) anyObject())).willReturn(contextMapping);
+
+        mockMvc.perform(put("/api/consumer/{consumerKey}/context/{context}", "consumerKey", "context")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(testObjectMapper.writeValueAsString(contextMapping)));
+    }
+
+    @Test
+    public void doesUpdateReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/consumer/consumerKey/context/context");
+
+        given(contextMappingRepository.save((ContextMapping) anyObject())).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = mockMvc.perform(put("/api/consumer/{consumerKey}/context/{context}", "consumerKey", "context")
+                                        .session(session)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                                        .andReturn();
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    @Test
+    public void doesGetReturnProperJsonWhenGivenValidInput() throws Exception {
+        given(contextMappingRepository.findByKeyAndContext(anyString(), anyString())).willReturn(contextMapping);
+
+        mockMvc.perform(get("/api/consumer/{consumerKey}/context/{context}", "consumerKey", "context")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(testObjectMapper.writeValueAsString(contextMapping)));
+    }
+
+    @Test
+    public void doesGetReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/consumer/consumerKey/context/context");
+
+        given(contextMappingRepository.findByKeyAndContext(anyString(), anyString())).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = mockMvc.perform(get("/api/consumer/{consumerKey}/context/{context}", "consumerKey", "context")
+                                        .session(session)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                                        .andReturn();
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    @Test
+    public void doesGetByIdReturnProperJsonWhenGivenValidInput() throws Exception {
+        given(contextMappingRepository.findOne(anyString())).willReturn(contextMapping);
+
+        mockMvc.perform(get("/api/cm/{id}", "id")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(testObjectMapper.writeValueAsString(contextMapping)));
+    }
+
+    @Test
+    public void doesGetByIdReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/cm/id");
+
+        given(contextMappingRepository.findOne(anyString())).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = mockMvc.perform(get("/api/cm/{id}", "id")
+                                        .session(session)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                                        .content(testObjectMapper.writeValueAsString(contextMapping)))
+                                        .andReturn();
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+}

--- a/src/test/java/od/controller/tests/ControllerTests.java
+++ b/src/test/java/od/controller/tests/ControllerTests.java
@@ -1,0 +1,316 @@
+package od.controller.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import lti.LaunchRequest;
+import od.AbstractTest;
+import od.test.groups.ControllerUnitTests;
+import od.utils.AppControllerAdvice;
+import od.utils.Response;
+
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Category(ControllerUnitTests.class)
+public abstract class ControllerTests extends AbstractTest {
+    private static final Logger logger = LoggerFactory.getLogger(ControllerTests.class);
+
+    // Leveraging object mapper to avoid writing json
+    protected ObjectMapper testObjectMapper;
+    protected MockHttpSession session;
+
+    protected static final String ERROR = "error";
+    protected static final String JSON_CONTENT_TYPE = "application/json;charset=utf-8";
+    protected static final String RESPONSE = "response";
+    protected static final String EXCEPTION_DATA_MESSAGE = "java.lang.RuntimeException: Call Didn't work!!";
+    protected static final String EXCEPTION_MESSAGE = "Call Didn't work!!";
+    protected static final String X_REQUESTED_WITH_AJAX_VALUE = "XMLHttpRequest";
+    protected static final String X_REQUESTED_WITH_HEADER_NAME = "X-Requested-With";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        testObjectMapper = new ObjectMapper();
+    }
+
+    protected MockHttpSession createSession() {
+        MockHttpSession session = new MockHttpSession();
+        return session;
+    }
+
+    protected Response createServiceCallExceptionExpectedResponse() {
+        return createExpectedResponse("", EXCEPTION_MESSAGE, EXCEPTION_DATA_MESSAGE);
+    }
+
+    protected Response createExpectedResponse(String url, String error, String data) {
+        Response expectedResponse = new Response();
+        expectedResponse.setUrl(url);
+        expectedResponse.setData(data);
+        List<String> errors = new ArrayList<String>();
+        errors.add(error);
+        expectedResponse.setErrors(errors);
+        return expectedResponse;
+    }
+
+    // Sets up advice controller
+    protected ExceptionHandlerExceptionResolver createExceptionResolver() {
+        ExceptionHandlerExceptionResolver exceptionResolver = new ExceptionHandlerExceptionResolver() {
+            @Override
+            protected ServletInvocableHandlerMethod getExceptionHandlerMethod(HandlerMethod handlerMethod, Exception exception) {
+                Method method = new ExceptionHandlerMethodResolver(AppControllerAdvice.class).resolveMethod(exception);
+                return new ServletInvocableHandlerMethod(new AppControllerAdvice(), method);
+            }
+        };
+        exceptionResolver.getMessageConverters().add(new MappingJackson2HttpMessageConverter());
+        exceptionResolver.afterPropertiesSet();
+        return exceptionResolver;
+    }
+
+    protected void validateActualResponseAgainstExpectedResponse(Response expectedResponse, Response actualResponse) throws IOException {
+//        logger.info("expected: {}\nactual: {}", expectedResponse.getUrl(), actualResponse.getUrl());
+        assertEquals(expectedResponse.getUrl(), actualResponse.getUrl());
+
+        int numberOfErrors = expectedResponse.getErrors().size();
+        for (int i = 0 ; i < numberOfErrors; i++) {
+//            logger.info("expected: {}\nactual: {}", expectedResponse.getErrors().get(i).toLowerCase(), actualResponse.getErrors().get(i).toLowerCase());
+            String expectedError = expectedResponse.getErrors().get(i).toLowerCase(Locale.ENGLISH);
+            String actualError = actualResponse.getErrors().get(i).toLowerCase(Locale.ENGLISH);
+            assertTrue(actualError.startsWith(expectedError));
+        }
+//        logger.info("expected: {}\nactual: {}", expectedResponse.getData().toString(), actualResponse.getData().toString());
+        String expectedData = expectedResponse.getData().toString();
+        String actualData = actualResponse.getData().toString();
+        assertTrue(actualData.startsWith(expectedData));
+    }
+
+    protected MockMvc createMockMvc(Object controller) {
+        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+        viewResolver.setPrefix("/WEB-INF/templates/");
+        viewResolver.setSuffix(".html");
+        return MockMvcBuilders.standaloneSetup(controller)
+                                      // This is for advice controller to be leveraged
+                                      .setHandlerExceptionResolvers(createExceptionResolver())
+                                      // This is for circular reference fix (do a get on /login and return to view login fails without this)
+                                      .setViewResolvers(viewResolver)
+                                      .build();
+    }
+
+    protected MockMvc createMockMvcForFilterException(Object controller) {
+        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+        viewResolver.setPrefix("/WEB-INF/templates/");
+        viewResolver.setSuffix(".html");
+        return MockMvcBuilders.standaloneSetup(controller)
+                                      // This is for circular reference fix (do a get on /login and return to view login fails without this)
+                                      .setViewResolvers(viewResolver)
+                                      .build();
+    }
+
+    protected MvcResult executeMockMvcGetModelAndViewServiceExceptionAndPartialValidation(String uri, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri).session(session))
+                .andExpect(view().name(ERROR))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().size(1))
+                .andExpect(model().attributeExists(RESPONSE))
+                .andReturn();
+    }
+
+    protected MvcResult executeMockMvcGetModelAndViewServiceExceptionAndPartialValidation(String uri, String uriId, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri, uriId).session(session))
+                .andExpect(view().name(ERROR))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().size(1))
+                .andExpect(model().attributeExists(RESPONSE))
+                .andReturn();
+    }
+
+    protected MvcResult executeMockMvcGetModelAndViewServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri, uriId, uriId1).session(session))
+                .andExpect(view().name(ERROR))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().size(1))
+                .andExpect(model().attributeExists(RESPONSE))
+                .andReturn();
+    }
+
+    protected MvcResult executeMockMvcGetModelAndViewServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, String uriId2, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri, uriId, uriId1, uriId2).session(session))
+                .andExpect(view().name(ERROR))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().size(1))
+                .andExpect(model().attributeExists(RESPONSE))
+                .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPostAjaxServiceExceptionAndPartialValidation(String uri, String uriId, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(post(uri, uriId).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPostAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(post(uri, uriId, uriId1).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPostAjaxServiceExceptionAndPartialValidation(String uri, String uriId, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(post(uri, uriId).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPostAjaxServiceExceptionAndPartialValidation(String uri, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(post(uri).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPutAjaxServiceExceptionAndPartialValidation(String uri, String uriId, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(put(uri, uriId).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPutAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(put(uri, uriId, uriId1).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPutAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, String uriId2, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(put(uri, uriId, uriId1, uriId2).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcPutAjaxServiceExceptionAndPartialValidation(String uri, Object model, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(put(uri).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(model)))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcDeleteAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(delete(uri, uriId, uriId1).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcDeleteAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, String uriId2, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(delete(uri, uriId, uriId1, uriId2).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcGetAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri, uriId, uriId1).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected MvcResult executeMockMvcGetAjaxServiceExceptionAndPartialValidation(String uri, String uriId, String uriId1, String uriId2, MockMvc mockMvc) throws Exception {
+        return mockMvc.perform(get(uri, uriId, uriId1, uriId2).session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE))
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andReturn();
+    }
+
+    protected Response getResponseFromMockMvcAjaxResult(MvcResult result) throws JsonParseException, JsonMappingException, IOException {
+        String actualResultContent = result.getResponse().getContentAsString();
+        return testObjectMapper.readValue(actualResultContent, Response.class);
+    }
+
+    protected Response getResponseFromMockMvcModelAndViewResult(MvcResult actualResult) {
+        return (Response) actualResult.getModelAndView().getModel().get(RESPONSE);
+    }
+
+    protected LaunchRequest createLaunchRequest() {
+        LaunchRequest launchRequest = new LaunchRequest();
+        launchRequest.setLti_message_type("Lti_message_type");
+        launchRequest.setLti_version("Lti_version");
+        launchRequest.setResource_link_id("Resource_link_id");
+        launchRequest.setContext_id("Context_id");
+        launchRequest.setUser_id("User_id");
+        launchRequest.setRoles("Roles");
+        launchRequest.setContext_type("Context_type");
+        launchRequest.setLaunch_presentation_locale("Launch_presentation_locale");
+        launchRequest.setRole_scope_mentor("Role_scope_mentor");
+        launchRequest.setUser_image("User_image");
+        launchRequest.setResource_link_title("Resource_link_title");
+        launchRequest.setLis_person_name_given("Lis_person_name_given");
+        launchRequest.setLis_person_name_family("Lis_person_name_family");
+        launchRequest.setLis_person_name_full("Lis_person_name_full");
+        launchRequest.setLis_person_contact_email_primary("Lis_person_contact_email_primary");
+        launchRequest.setContext_title("Context_title");
+        launchRequest.setContext_label("Context_label");
+        launchRequest.setOauth_signature_method("HMAC-SHA1");
+        launchRequest.setOauth_timestamp("Oauth_timestamp");
+        launchRequest.setOauth_nonce("Oauth_nonce");
+        launchRequest.setOauth_version("Oauth_version");
+        launchRequest.setOauth_callback("Oauth_callback");
+        launchRequest.setRoles("Instructor,Administrator,urn:lti:instrole:ims/lis/Administrator,urn:lti:sysrole:ims/lis/Administrator");
+        return launchRequest;
+    }
+}

--- a/src/test/java/od/controller/tests/LTIProxyControllerTest.java
+++ b/src/test/java/od/controller/tests/LTIProxyControllerTest.java
@@ -1,0 +1,158 @@
+package od.controller.tests;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+
+import lti.LaunchRequest;
+import lti.ProxiedLaunch;
+import od.cards.lti.LTIProxyController;
+import od.model.Card;
+import od.model.ContextMapping;
+import od.repository.ContextMappingRepositoryInterface;
+import od.utils.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class LTIProxyControllerTest extends ControllerTests {
+    private static final Logger logger = LoggerFactory.getLogger(LTIProxyControllerTest.class);
+
+    @Mock
+    private ContextMapping contextMapping;
+    @Mock
+    private Card card;
+    @Mock
+    private ContextMappingRepositoryInterface contextMappingRepository;
+
+    @InjectMocks
+    private LTIProxyController ltiProxyController;
+
+    private MockMvc mockMvc;
+    private Response serviceFailureExpectedResponse;
+
+    // Setting up to have the spring app context in place while still being able to mock/control
+    // the services the controller uses.
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        MockitoAnnotations.initMocks(this);
+        session = this.createSession();
+        serviceFailureExpectedResponse = createServiceCallExceptionExpectedResponse();
+        this.mockMvc = this.createMockMvc(ltiProxyController);
+    }
+
+    @Test
+    public void doesProxyReturnProperJsonWhenGivenValidInput() throws Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        Map<String, Object> config = createConfig();
+
+        given(contextMappingRepository.findOne("contextMappingId")).willReturn(contextMapping);
+        given(contextMapping.findCard("cardId")).willReturn(card);
+        given(card.getConfig()).willReturn(config);
+
+        mockMvc.perform(post("/api/{contextMappingId}/lti/launch/{cardId}", "contextMappingId", "cardId")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(launchRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(JSON_CONTENT_TYPE))
+                        .andExpect(content().string(testObjectMapper.writeValueAsString(createProxyLaunchRequest())));
+    }
+
+    @Test
+    public void doesProxyReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        Map<String, Object> config = createConfig();
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/contextMappingId/lti/launch/cardId");
+
+        given(contextMappingRepository.findOne("contextMappingId")).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+        given(contextMapping.findCard("cardId")).willReturn(card);
+        given(card.getConfig()).willReturn(config);
+
+        MvcResult actualResult = executeMockMvcPostAjaxServiceExceptionAndPartialValidation("/api/{contextMappingId}/lti/launch/{cardId}", "contextMappingId", "cardId", launchRequest, mockMvc);
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    private Map<String, Object> createConfig() {
+        Map<String,Object> config = new HashMap<>();
+        config.put("launchUrl", "http://test.com");
+        config.put("key", "test");
+        config.put("secret", "test");
+        return config;
+    }
+
+    private ProxiedLaunch createProxyLaunchRequest() {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        LaunchRequest proxiedLaunchRequest = new LaunchRequest(
+                launchRequest.getLti_message_type(),
+                launchRequest.getLti_version(),
+                launchRequest.getResource_link_id(),
+                launchRequest.getContext_id(),
+                null, //Launch_presentation_document_target
+                null, //Launch_presentation_width
+                null, //Launch_presentation_height
+                null, //Launch_presentation_return_url
+                launchRequest.getUser_id(),
+                launchRequest.getRoles(),
+                launchRequest.getContext_type(),
+                launchRequest.getLaunch_presentation_locale(),
+                null, //Launch_presentation_css_url
+                launchRequest.getRole_scope_mentor(),
+                launchRequest.getUser_image(),
+                null, // custom
+                null, // ext
+                launchRequest.getResource_link_title(),
+                null, // resource_link_description
+                launchRequest.getLis_person_name_given(),
+                launchRequest.getLis_person_name_family(),
+                launchRequest.getLis_person_name_full(),
+                launchRequest.getLis_person_contact_email_primary(),
+
+                // TODO make passing outcomes related configurable
+                null, //lis_outcome_service_url
+                null, //lis_result_sourcedid
+
+                launchRequest.getContext_title(),
+                launchRequest.getContext_label(),
+                null, //Tool_consumer_info_product_family_code
+                null, //Tool_consumer_info_version
+                "OpenDashboard", //Tool_consumer_instance_guid
+                null, //Tool_consumer_instance_name
+                null, //Tool_consumer_instance_description
+                null, //Tool_consumer_instance_url
+                null, //Tool_consumer_instance_contact_email
+                "test", // oauth_consumer_key
+                launchRequest.getOauth_signature_method(),
+                launchRequest.getOauth_timestamp(),
+                launchRequest.getOauth_nonce(),
+                launchRequest.getOauth_version(),
+                null, // null oauth_signature is intentional; we calculate it later
+                launchRequest.getOauth_callback());
+        SortedMap<String,String> sortedParams = proxiedLaunchRequest.toSortedMap();
+        sortedParams.put("oauth_signature", "UZSEW8BE9AMHuwfE2sNaOC5+4E8=");
+        ProxiedLaunch proxyLaunch = new ProxiedLaunch(sortedParams, "http://test.com");
+
+        return proxyLaunch;
+    }
+
+}

--- a/src/test/java/od/controller/tests/OpenDashControllerTest.java
+++ b/src/test/java/od/controller/tests/OpenDashControllerTest.java
@@ -1,0 +1,106 @@
+package od.controller.tests;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyObject;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import lti.LaunchRequest;
+import od.controllers.OpenDashController;
+import od.repository.SessionRepositoryInterface;
+import od.utils.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class OpenDashControllerTest extends ControllerTests {
+    private static final Logger logger = LoggerFactory.getLogger(OpenDashControllerTest.class);
+
+    @Mock
+    private SessionRepositoryInterface sessionRepository;
+    @Mock
+    private od.model.Session openDashSession;
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @InjectMocks
+    private OpenDashController openDashController;
+
+    private MockMvc mockMvc;
+    private Response serviceFailureExpectedResponse;
+
+    // Setting up to have the spring app context in place while still being able to mock/control
+    // the services the controller uses.
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        MockitoAnnotations.initMocks(this);
+        session = this.createSession();
+        serviceFailureExpectedResponse = createServiceCallExceptionExpectedResponse();
+        openDashController.setAuthenticationManager(authenticationManager);
+        this.mockMvc = this.createMockMvc(openDashController);
+    }
+
+    @Test
+    public void doesLtiReturnProperModelAndViewWhenGivenValidInput() throws Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        given(sessionRepository.save((od.model.Session)anyObject())).willReturn(openDashSession);
+        given(openDashSession.getId()).willReturn("sessionId");
+
+        mockMvc.perform(post("/")
+                        .session(session)
+                        .param("roles", "Instructor,Administrator,urn:lti:instrole:ims/lis/Administrator,urn:lti:sysrole:ims/lis/Administrator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(testObjectMapper.writeValueAsString(launchRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(view().name("od"))
+                        .andExpect(model().size(2))
+                        .andExpect(model().attributeExists("inbound_lti_launch_request", "token"));
+    }
+
+    @Test
+    public void doesLtiReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        serviceFailureExpectedResponse.setUrl("http://localhost/");
+        given(authenticationManager.authenticate((Authentication)anyObject())).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = mockMvc.perform(post("/")
+                                .session(session)
+                                .param("roles", "Instructor,Administrator,urn:lti:instrole:ims/lis/Administrator,urn:lti:sysrole:ims/lis/Administrator")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(testObjectMapper.writeValueAsString(launchRequest)))
+                                .andReturn();
+
+        Response actualResponse = this.getResponseFromMockMvcModelAndViewResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    @Test
+    public void doesRoutesReturnProperModelAndViewWhenGivenValidInput() throws Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+
+        mockMvc.perform(get("/")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(testObjectMapper.writeValueAsString(launchRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(view().name("od"))
+                        .andExpect(model().size(0));
+    }
+
+}

--- a/src/test/java/od/controller/tests/OpenLRSControllerTest.java
+++ b/src/test/java/od/controller/tests/OpenLRSControllerTest.java
@@ -1,0 +1,118 @@
+package od.controller.tests;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lti.LaunchRequest;
+import od.cards.openlrs.OpenLRSCardController;
+import od.cards.openlrs.OpenLRSCardController.RestTemplateFactoryInterface;
+import od.model.Card;
+import od.model.ContextMapping;
+import od.repository.ContextMappingRepositoryInterface;
+import od.utils.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class OpenLRSControllerTest extends ControllerTests {
+    private static final Logger logger = LoggerFactory.getLogger(OpenLRSControllerTest.class);
+
+    @Mock
+    private ContextMapping contextMapping;
+    @Mock
+    private Card card;
+    @Mock
+    private RestTemplateFactoryInterface restTemplateFactory;
+    @Mock
+    private RestTemplate restTemplate;
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private ResponseEntity response;
+    @Mock
+    private ContextMappingRepositoryInterface contextMappingRepository;
+
+    @InjectMocks
+    private OpenLRSCardController openLRSController;
+
+    private MockMvc mockMvc;
+    private Response serviceFailureExpectedResponse;
+
+    // Setting up to have the spring app context in place while still being able to mock/control
+    // the services the controller uses.
+    @SuppressWarnings("unchecked")
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        MockitoAnnotations.initMocks(this);
+        serviceFailureExpectedResponse = createServiceCallExceptionExpectedResponse();
+        session = this.createSession();
+        openLRSController.setRestTemplateFactory(restTemplateFactory);
+        given(restTemplateFactory.createRestTemplate()).willReturn(restTemplate);
+        given(restTemplate.exchange(anyString(), any(HttpMethod.class), (HttpEntity<String>)anyObject(), anyClass())).willReturn(response);
+        given(response.getBody()).willReturn("body");
+        this.mockMvc = this.createMockMvc(openLRSController);
+    }
+
+    @Test
+    public void doesGetOpenLRSStatementsReturnProperJsonWhenGivenValidInput() throws Exception {
+        LaunchRequest launchRequest = this.createLaunchRequest();
+        Map<String, Object> config = createConfig();
+
+        given(contextMappingRepository.findOne("contextMappingId")).willReturn(contextMapping);
+        given(contextMapping.findCard("cardId")).willReturn(card);
+        given(contextMapping.getContext()).willReturn("contextId");
+        given(card.getConfig()).willReturn(config);
+
+        mockMvc.perform(get("/api/{contextMappingId}/db/{dashboardId}/openlrs/{cardId}/statements", "contextMappingId", "dashboardId", "cardId")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(X_REQUESTED_WITH_HEADER_NAME, X_REQUESTED_WITH_AJAX_VALUE)
+                        .content(testObjectMapper.writeValueAsString(launchRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string("body"));
+    }
+
+    @Test
+    public void doesGetOpenLRSStatementsReturnExceptionWhenExceptionIsThrown() throws JsonProcessingException, Exception {
+        serviceFailureExpectedResponse.setUrl("http://localhost/api/contextMappingId/db/dashboardId/openlrs/cardId/statements");
+        given(contextMappingRepository.findOne("contextMappingId")).willThrow(new RuntimeException(EXCEPTION_MESSAGE));
+
+        MvcResult actualResult = executeMockMvcGetAjaxServiceExceptionAndPartialValidation("/api/{contextMappingId}/db/{dashboardId}/openlrs/{cardId}/statements", "contextMappingId", "dashboardId", "cardId", mockMvc);
+
+        Response actualResponse = this.getResponseFromMockMvcAjaxResult(actualResult);
+        validateActualResponseAgainstExpectedResponse(serviceFailureExpectedResponse, actualResponse);
+    }
+
+    private Map<String, Object> createConfig() {
+        Map<String,Object> config = new HashMap<>();
+        config.put("launchUrl", "http://test.com");
+        config.put("key", "test");
+        config.put("secret", "test");
+        config.put("url", "http://test.com");
+        return config;
+    }
+
+}

--- a/src/test/java/od/model/tests/ModelTests.java
+++ b/src/test/java/od/model/tests/ModelTests.java
@@ -1,0 +1,37 @@
+package od.model.tests;
+
+import od.AbstractTest;
+import od.test.groups.ModelUnitTests;
+
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+
+import com.openpojo.validation.PojoValidator;
+import com.openpojo.validation.rule.impl.GetterMustExistRule;
+import com.openpojo.validation.rule.impl.NoPublicFieldsRule;
+import com.openpojo.validation.rule.impl.NoStaticExceptFinalRule;
+import com.openpojo.validation.rule.impl.SetterMustExistRule;
+import com.openpojo.validation.test.impl.GetterTester;
+import com.openpojo.validation.test.impl.SetterTester;
+
+@Category(ModelUnitTests.class)
+public abstract class ModelTests extends AbstractTest {
+
+    protected PojoValidator modelValidator;
+
+    @Before
+    public void setup() {
+        modelValidator = new PojoValidator();
+
+        // Create Rules to validate structure for MODEL_PACKAGE
+        modelValidator.addRule(new NoPublicFieldsRule());
+        modelValidator.addRule(new NoStaticExceptFinalRule());
+        modelValidator.addRule(new GetterMustExistRule());
+        modelValidator.addRule(new SetterMustExistRule());
+
+        // Create Testers to validate behavior for MODEL_PACKAGE
+        modelValidator.addTester(new SetterTester());
+        modelValidator.addTester(new GetterTester());
+    }
+
+}

--- a/src/test/java/od/model/tests/OpenDashModelTests.java
+++ b/src/test/java/od/model/tests/OpenDashModelTests.java
@@ -1,0 +1,42 @@
+package od.model.tests;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.affirm.Affirm;
+
+public class OpenDashModelTests extends ModelTests {
+    // Configured for expectation, so we know when a class gets added or removed.
+    private static final int EXPECTED_CLASS_COUNT = 5;
+
+    // The package to test
+    private static final String MODEL_PACKAGE = "od.model";
+
+    private List<PojoClass> modelClasses;
+
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        modelClasses = PojoClassFactory.getPojoClasses(MODEL_PACKAGE);
+    }
+
+
+    @Test
+    public void ensureExpectedModelCount() {
+        Affirm.affirmEquals("Classes added / removed?", EXPECTED_CLASS_COUNT, modelClasses.size());
+    }
+
+    @Test
+    public void testModelStructureAndBehavior() {
+        for (PojoClass pojoClass : modelClasses) {
+            if(!pojoClass.getName().endsWith("List")) {
+                modelValidator.runValidation(pojoClass);
+            }
+        }
+    }
+}

--- a/src/test/java/od/model/tests/RedisModelTests.java
+++ b/src/test/java/od/model/tests/RedisModelTests.java
@@ -1,0 +1,42 @@
+package od.model.tests;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.affirm.Affirm;
+
+public class RedisModelTests extends ModelTests {
+    // Configured for expectation, so we know when a class gets added or removed.
+    private static final int EXPECTED_CLASS_COUNT = 2;
+
+    // The package to test
+    private static final String MODEL_PACKAGE = "od.repository.redis.model";
+
+    private List<PojoClass> modelClasses;
+
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        modelClasses = PojoClassFactory.getPojoClasses(MODEL_PACKAGE);
+    }
+
+
+    @Test
+    public void ensureExpectedModelCount() {
+        Affirm.affirmEquals("Classes added / removed?", EXPECTED_CLASS_COUNT, modelClasses.size());
+    }
+
+    @Test
+    public void testModelStructureAndBehavior() {
+        for (PojoClass pojoClass : modelClasses) {
+            if(!pojoClass.getName().endsWith("List")) {
+                modelValidator.runValidation(pojoClass);
+            }
+        }
+    }
+}

--- a/src/test/java/od/test/groups/ControllerUnitTests.java
+++ b/src/test/java/od/test/groups/ControllerUnitTests.java
@@ -1,0 +1,3 @@
+package od.test.groups;
+
+public interface ControllerUnitTests { }

--- a/src/test/java/od/test/groups/ModelUnitTests.java
+++ b/src/test/java/od/test/groups/ModelUnitTests.java
@@ -1,0 +1,3 @@
+package od.test.groups;
+
+public interface ModelUnitTests {}

--- a/src/test/resources/application-mongo.properties
+++ b/src/test/resources/application-mongo.properties
@@ -1,0 +1,16 @@
+server.port=8080
+spring.thymeleaf.cache=false
+
+dashboards.preconfigured.allow=false
+
+auth.oauth.key=opendash
+auth.oauth.secret=opendash
+
+# Mongo settings
+
+spring.data.mongodb.uri=mongodb://localhost/od
+
+# Logging settings
+logging.level.org.springframework=INFO
+logging.level.org.springframework.security=DEBUG
+logging.level.od=DEBUG

--- a/src/test/resources/application-redis.properties
+++ b/src/test/resources/application-redis.properties
@@ -1,0 +1,27 @@
+server.port=8080
+spring.thymeleaf.cache=false
+
+dashboards.preconfigured.allow=false
+
+auth.oauth.key=opendash
+auth.oauth.secret=opendash
+
+# Redis settings
+redis.namespace=opendash
+#spring.redis.database= # database name
+spring.redis.host=127.0.0.1
+#spring.redis.password= # server password
+spring.redis.port=6379
+#spring.redis.pool.max-idle=8 # pool settings ...
+#spring.redis.pool.min-idle=0
+#spring.redis.pool.max-active=8
+#spring.redis.pool.max-wait=-1
+
+# uncomment these lines if you are using redis sentinel for HA
+#spring.redis.sentinel.master=mymaster
+#spring.redis.sentinel.nodes=127.0.0.1:17700
+
+# Logging settings
+logging.level.org.springframework=INFO
+logging.level.org.springframework.security=DEBUG
+logging.level.od=DEBUG


### PR DESCRIPTION
Adding controller and some model unit tests and unit test report generator.
Adding controller advise class for exception handling of exceptions thrown while in controller contexts.
Other contexts like Oauth filter(web filters) and Thymeleaf errors will go to the same error page but are not effected by this advise controller.
Updated error page to display some error data.
Updated Readme with instructions for sending in testing profile for the unit tests.
Removed implements ErrorController, there is a BasicErrorController that is autoconfigured and provides this functionality.
Unit Tests needed an auth bean defined to work, this had no impact on runtime behavior from the testing done.