### PR TITLE
 "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/lti/LaunchRequest.java
+++ b/src/main/java/lti/LaunchRequest.java
@@ -90,8 +90,8 @@ public class LaunchRequest extends LtiMessage {
   public LaunchRequest(Map<String, String[]> paramMap) {
     Map<String, String> flattenedParams = new TreeMap<String, String>();
 
-    for (String key : paramMap.keySet()) {
-      String[] values = paramMap.get(key);
+    for (Map.Entry<String, String[]> entry : paramMap.entrySet()) {
+      String[] values = entry.getValue();
       String value = null;
       if (values != null && values.length > 0) {
         for (String v : values) {
@@ -103,7 +103,7 @@ public class LaunchRequest extends LtiMessage {
           }
         }
       }
-      flattenedParams.put(key, value);
+      flattenedParams.put(entry.getKey(), value);
     }
 
     init(flattenedParams);
@@ -181,22 +181,22 @@ public class LaunchRequest extends LtiMessage {
 
     if (custom != null && !custom.isEmpty()) {
       Set<String> keys = custom.keySet();
-      for (String key : keys) {
-        sm.put(key, custom.get(key));
+      for (Map.Entry<String, String> entry : custom.entrySet()) {
+        sm.put(entry.getKey(), entry.getValue());
       }
     }
 
     if (ext != null && !ext.isEmpty()) {
       Set<String> keys = ext.keySet();
-      for (String key : keys) {
-        sm.put(key, ext.get(key));
+      for (Map.Entry<String, String> entry : ext.entrySet()) {
+        sm.put(entry.getKey(), entry.getValue());
       }
     }
 
     if (extra != null && !extra.isEmpty()) {
       Set<String> keys = extra.keySet();
-      for (String key : keys) {
-        sm.put(key, extra.get(key));
+      for (Map.Entry<String, String> entry : extra.entrySet()) {
+        sm.put(entry.getKey(), entry.getValue());
       }
     }
 
@@ -533,29 +533,29 @@ public class LaunchRequest extends LtiMessage {
     if (paramMap != null && !paramMap.isEmpty()) {
       Set<String> keys = paramMap.keySet();
       if (keys != null && !keys.isEmpty()) {
-        for (String key : keys) {
-          if (key != null && key.startsWith("custom_")) {
+        for (Map.Entry<String, String> entry : paramMap.entrySet()) {
+          if (entry.getKey() != null && entry.getKey().startsWith("custom_")) {
             if (this.custom == null) {
               this.custom = new HashMap<String, String>();
             }
 
-            this.custom.put(key, paramMap.get(key));
-          } else if (key != null && key.startsWith("ext_")) {
+            this.custom.put(entry.getKey(), entry.getValue());
+          } else if (entry.getKey() != null && entry.getKey().startsWith("ext_")) {
             if (this.ext == null) {
               this.ext = new HashMap<String, String>();
             }
 
-            this.ext.put(key, paramMap.get(key));
+            this.ext.put(entry.getKey(), entry.getValue());
           } else {
 
             // If we don't have the key at this point, it's likely a
             // unknown type that we didn't account for. We still need
             // to add it for the oauth comparison
-            if (currentSM != null && !currentSM.containsValue(key)) {
+            if (currentSM != null && !currentSM.containsValue(entry.getKey())) {
               if (this.extra == null) {
                 this.extra = new HashMap<String, String>();
               }
-              this.extra.put(key, paramMap.get(key));
+              this.extra.put(entry.getKey(), entry.getValue());
             }
           }
         }

--- a/src/main/java/lti/oauth/OAuthMessageSigner.java
+++ b/src/main/java/lti/oauth/OAuthMessageSigner.java
@@ -19,6 +19,7 @@ package lti.oauth;
 
 import java.net.URLEncoder;
 import java.security.MessageDigest;
+import java.util.Map;
 import java.util.SortedMap;
 
 import javax.crypto.Mac;
@@ -63,11 +64,11 @@ public class OAuthMessageSigner {
         signatureBase.append(OAuthUtil.AMPERSAND);
 
         int count = 0;
-        for (String key : parameters.keySet()) {
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
             count++;
-               signatureBase.append(OAuthUtil.percentEncode(OAuthUtil.percentEncode(key)));
+               signatureBase.append(OAuthUtil.percentEncode(OAuthUtil.percentEncode(entry.getKey())));
             signatureBase.append(URLEncoder.encode(OAuthUtil.EQUAL, OAuthUtil.ENCODING));
-            signatureBase.append(OAuthUtil.percentEncode(OAuthUtil.percentEncode(parameters.get(key))));
+            signatureBase.append(OAuthUtil.percentEncode(OAuthUtil.percentEncode(entry.getValue())));
 
             if (count < parameters.size()) {
                 signatureBase.append(URLEncoder.encode(OAuthUtil.AMPERSAND, OAuthUtil.ENCODING));

--- a/src/main/java/lti/oauth/OAuthUtil.java
+++ b/src/main/java/lti/oauth/OAuthUtil.java
@@ -84,13 +84,13 @@ public class OAuthUtil {
         }
         
         if (parameters != null && !parameters.isEmpty()) {
-            for (String key : parameters.keySet()) {
-                if (key.startsWith("oauth_")) {
-                    String value = parameters.get(key);
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                if (entry.getKey().startsWith("oauth_")) {
+                    String value = entry.getValue();
                     if (value == null) value = "";
                     if (header.length() > 0) header.append(",");
                     header.append(" ");
-                    header.append(OAuthUtil.percentEncode(key)).append("=\"");
+                    header.append(OAuthUtil.percentEncode(entry.getKey())).append("=\"");
                     header.append(OAuthUtil.percentEncode(value)).append('"');
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.