### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/lti/oauth/OAuthMessageSigner.java
+++ b/src/main/java/lti/oauth/OAuthMessageSigner.java
@@ -52,7 +52,7 @@ public class OAuthMessageSigner {
      */
     public String sign(String secret, String algorithm, String method,
                 String url, SortedMap<String, String> parameters) throws Exception {
-        SecretKeySpec secretKeySpec = new SecretKeySpec((secret.concat(OAuthUtil.AMPERSAND)).getBytes(),algorithm);
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secret.concat(OAuthUtil.AMPERSAND).getBytes(),algorithm);
         Mac mac = Mac.getInstance(secretKeySpec.getAlgorithm());
         mac.init(secretKeySpec);
 

--- a/src/main/java/od/providers/modeloutput/lap/LAPModelOutputProvider.java
+++ b/src/main/java/od/providers/modeloutput/lap/LAPModelOutputProvider.java
@@ -152,7 +152,7 @@ public class LAPModelOutputProvider extends BaseProvider implements ModelOutputP
   public Page<ModelOutput> getModelOutputForCourse(ProviderOptions options, String tenant, String course, Pageable pageable) throws ProviderException {
     Map<String, String> urlVariables = new HashMap<String, String>();
     urlVariables.put("id", course);
-    urlVariables.put("tenant", (StringUtils.isNotBlank(tenant)) ? tenant : "lap");
+    urlVariables.put("tenant", StringUtils.isNotBlank(tenant) ? tenant : "lap");
     
     return fetch(urlVariables, pageable, "/api/output/{tenant}/course/{id}?lastRunOnly=true");
   }
@@ -161,7 +161,7 @@ public class LAPModelOutputProvider extends BaseProvider implements ModelOutputP
   public Page<ModelOutput> getModelOutputForStudent(ProviderOptions options, String tenant, String student, Pageable pageable) throws ProviderException {
     Map<String, String> urlVariables = new HashMap<String, String>();
     urlVariables.put("id", student);
-    urlVariables.put("tenant", (StringUtils.isNotBlank(tenant)) ? tenant : "lap");
+    urlVariables.put("tenant", StringUtils.isNotBlank(tenant) ? tenant : "lap");
     
     return fetch(urlVariables, pageable, "/api/outpu/{tenant}t/student/{id}");
   }

--- a/src/main/java/od/providers/roster/basiclis/BasicLISRosterProvider.java
+++ b/src/main/java/od/providers/roster/basiclis/BasicLISRosterProvider.java
@@ -142,7 +142,7 @@ public class BasicLISRosterProvider implements RosterProvider {
     map.add(OAuthUtil.CONSUMER_KEY_PARAM, providerData.findValueForKey("oauth_consumer_key"));
     map.add(OAuthUtil.SIGNATURE_METHOD_PARAM, "HMAC-SHA1");
     map.add(OAuthUtil.VERSION_PARAM, "1.0");
-    map.add(OAuthUtil.TIMESTAMP_PARAM, new Long((new Date().getTime()) / 1000).toString());
+    map.add(OAuthUtil.TIMESTAMP_PARAM, new Long(new Date().getTime() / 1000).toString());
     map.add(OAuthUtil.NONCE_PARAM, UUID.randomUUID().toString());
     try {
       map.add(OAuthUtil.SIGNATURE_PARAM,

--- a/src/main/java/od/repository/mongo/MultiTenantMongoDbFactory.java
+++ b/src/main/java/od/repository/mongo/MultiTenantMongoDbFactory.java
@@ -67,7 +67,7 @@ public class MultiTenantMongoDbFactory extends SimpleMongoDbFactory {
   public DB getDb() {
     logger.debug("tenant service {}", tenantService.getTenant());
     final String tlName = tenantService.getTenant();
-    final String dbToUse = (tlName != null ? tlName : this.defaultName);
+    final String dbToUse = tlName != null ? tlName : this.defaultName;
     logger.debug("Acquiring database: " + dbToUse);
     createIndexIfNecessaryFor(dbToUse);
     return super.getDb(dbToUse);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.