### PR TITLE
Link the Google Groups web interfaces for OpenDashboard lists.

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,10 +523,16 @@ the means supported by Spring Boot.
       <div class="container text-center">
         <ul class="list-unstyled">
           <li><a href="mailto:opendashboard-user@apereo.org"><i
-              class="fa fa-envelope"></i> User List</a></li>
+              class="fa fa-envelope"></i> User List</a>
+              <a href="https://groups.google.com/a/apereo.org/forum/#!forum/opendashboard-user">
+                <i class="fa fa-globe" aria-hidden="true"></i> (on Web)</a>
+          </li>
           <li class="last"><a
             href="mailto:opendashboard-dev@apereo.org"><i
-              class="fa fa-envelope"></i> Developer List</a></li>
+              class="fa fa-envelope"></i> Developer List</a>
+              <a href="https://groups.google.com/a/apereo.org/forum/#!forum/opendashboard-dev">
+                <i class="fa fa-globe" aria-hidden="true"></i> (on Web)</a>
+            </li>
         </ul>
       </div>
       <p class="intro  text-center">To subscribe or unsubscribe send


### PR DESCRIPTION
Update the Mailing Lists section of the Open Dashboard website to also link the Google Groups web interface, besides providing the email addresses of the lists.

Before:

![open_dashboard_contact_before](https://cloud.githubusercontent.com/assets/952283/14987918/2ded020a-1117-11e6-8a8f-683b2e0130bd.png)

After:

![open_dashboard_contact_after](https://cloud.githubusercontent.com/assets/952283/14987916/2ba197ea-1117-11e6-82e8-4790ec047787.png)