### PR TITLE
Add badge indicating Apereo incubating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ OpenDashboard
 ============================
 A web application that provides a framework for displaying visualizations and data views called "cards". Cards represent a single discrete visualization or data view but share an API and data model.
 
+[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
+
 Find detailed documentation on our [github.io site](http://apereo-learning-analytics-initiative.github.io/OpenDashboard/).
 *************************************************************************************
 


### PR DESCRIPTION
Adds a badge to the README highlighting that OpenDashboard is incubating in Apereo.

[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation) 

[A better badge for this purpose may emerge in the future](https://groups.google.com/a/apereo.org/d/msg/incubation/p2h2ypnATO0/Du7LRiyFEQAJ). In the meantime, this changeset makes immediate progress in better communicating that this project is currently incubating.